### PR TITLE
Fix zone append in ZNSSSD mode

### DIFF
--- a/hw/femu/zns/zns.c
+++ b/hw/femu/zns/zns.c
@@ -1059,6 +1059,9 @@ static uint16_t zns_do_write(FemuCtrl *n, NvmeRequest *req, bool append,
     NvmeZonedResult *res = (NvmeZonedResult *)&req->cqe;
     uint16_t status;
 
+    assert(n->zoned);
+    req->is_write = true;
+
     if (!wrz) {
         status = nvme_check_mdts(n, data_size);
         if (status) {


### PR DESCRIPTION
### Fixes #91 
Fix a bug on ZNSSSD mode that makes zone append won't write anything. This bug is caused by the zone append function that didn't change `is_write` parameter to `True`. The issue is fixed by changing the `req->is_write` parameter.