### PR TITLE
Fix 5.19 Kernel NVMe CC issue

### DIFF
--- a/hw/femu/femu.c
+++ b/hw/femu/femu.c
@@ -90,6 +90,13 @@ static void nvme_write_bar(FemuCtrl *n, hwaddr offset, uint64_t data, unsigned s
         n->bar.intmc = n->bar.intms;
         break;
     case 0x14:
+        /* If first sending data, then sending enable bit */
+        if (!NVME_CC_EN(data) && !NVME_CC_EN(n->bar.cc) &&
+                !NVME_CC_SHN(data) && !NVME_CC_SHN(n->bar.cc))
+        {
+            n->bar.cc = data;
+        }
+
         if (NVME_CC_EN(data) && !NVME_CC_EN(n->bar.cc)) {
             n->bar.cc = data;
             if (nvme_start_ctrl(n)) {


### PR DESCRIPTION
Hi all,
I had issues emulating nvme devices with a 5.19 Kernel. I tested Kernels 5.15-5.18, which all worked fine, however on 5.19 the devices didn't show up. I was always getting errors on the device not being ready. 

I'm adding my steps for reproducing in case there is a more elegant fix than what I propose here.

## Setup

- Image with 5.19 Kernel
- femu device is set with: `-device femu,devsz_mb=8192,femu_mode=3,id=nvme0` (this is ZNS but none of the modes worked), other options are the same as in the `femu-scripts/run-zns.sh`

## Error

This was the initial error after booting the VM, but the device did show up on pci info.

```bash
[   1.213689] nvme nvme0: pci function 0000:00:05.0
[   9.238541] nvme nvme0: Device not ready; aborting initialisation, CSTS=0x2
[   9.312561] nvme nvme0: Removing after probe failure status: -19
```

Removing the device from pci and rescanning pci resulted in the same error.


## Fix

Adding the if statement to set the `n->bar.cc`  in the `nvme_write_bar` function, solved this issue for me. 
 I have the nvme device showing up and working fine.
I'm not sure if this is the most elegant fix. Do let me know if there are better ways of dealing with this?