### PR TITLE
Add Delay Emulation to FEMU ZNS Mode

### DIFF
--- a/femu-scripts/run-zns.sh
+++ b/femu-scripts/run-zns.sh
@@ -21,14 +21,16 @@ fi
 ssd_size=4096
 num_channels=2
 num_chips_per_channel=4
-latency=40000
+read_latency=40000
+write_latency=200000
 
 FEMU_OPTIONS="-device femu"
 FEMU_OPTIONS=${FEMU_OPTIONS}",devsz_mb=${ssd_size}"
 FEMU_OPTIONS=${FEMU_OPTIONS}",namespaces=1"
 FEMU_OPTIONS=${FEMU_OPTIONS}",zns_num_ch=${num_channels}"
 FEMU_OPTIONS=${FEMU_OPTIONS}",zns_num_lun=${num_chips_per_channel}"
-FEMU_OPTIONS=${FEMU_OPTIONS}",zns_latency=${latency}"
+FEMU_OPTIONS=${FEMU_OPTIONS}",zns_read=${read_latency}"
+FEMU_OPTIONS=${FEMU_OPTIONS}",zns_write=${write_latency}"
 FEMU_OPTIONS=${FEMU_OPTIONS}",femu_mode=3"
 
 sudo x86_64-softmmu/qemu-system-x86_64 \

--- a/femu-scripts/run-zns.sh
+++ b/femu-scripts/run-zns.sh
@@ -18,6 +18,19 @@ if [[ ! -e "$OSIMGF" ]]; then
 	exit
 fi
 
+ssd_size=4096
+num_channels=2
+num_chips_per_channel=4
+latency=40000
+
+FEMU_OPTIONS="-device femu"
+FEMU_OPTIONS=${FEMU_OPTIONS}",devsz_mb=${ssd_size}"
+FEMU_OPTIONS=${FEMU_OPTIONS}",namespaces=1"
+FEMU_OPTIONS=${FEMU_OPTIONS}",zns_num_ch=${num_channels}"
+FEMU_OPTIONS=${FEMU_OPTIONS}",zns_num_lun=${num_chips_per_channel}"
+FEMU_OPTIONS=${FEMU_OPTIONS}",zns_latency=${latency}"
+FEMU_OPTIONS=${FEMU_OPTIONS}",femu_mode=3"
+
 sudo x86_64-softmmu/qemu-system-x86_64 \
     -name "FEMU-ZNSSD-VM" \
     -enable-kvm \
@@ -27,7 +40,7 @@ sudo x86_64-softmmu/qemu-system-x86_64 \
     -device virtio-scsi-pci,id=scsi0 \
     -device scsi-hd,drive=hd0 \
     -drive file=$OSIMGF,if=none,aio=native,cache=none,format=qcow2,id=hd0 \
-    -device femu,devsz_mb=4096,femu_mode=3 \
+    ${FEMU_OPTIONS} \
     -net user,hostfwd=tcp::8080-:22 \
     -net nic,model=virtio \
     -nographic \

--- a/hw/femu/femu.c
+++ b/hw/femu/femu.c
@@ -654,6 +654,8 @@ static Property femu_props[] = {
     DEFINE_PROP_UINT8("lnum_lun", FemuCtrl, oc_params.num_lun, 8),
     DEFINE_PROP_UINT8("lnum_pln", FemuCtrl, oc_params.num_pln, 2),
     DEFINE_PROP_UINT16("lmetasize", FemuCtrl, oc_params.sos, 16),
+    DEFINE_PROP_UINT8("zns_num_ch", FemuCtrl, zns_params.zns_num_ch, 2),
+    DEFINE_PROP_UINT8("zns_num_lun", FemuCtrl, zns_params.zns_num_lun, 4),
     DEFINE_PROP_END_OF_LIST(),
 };
 

--- a/hw/femu/femu.c
+++ b/hw/femu/femu.c
@@ -656,6 +656,7 @@ static Property femu_props[] = {
     DEFINE_PROP_UINT16("lmetasize", FemuCtrl, oc_params.sos, 16),
     DEFINE_PROP_UINT8("zns_num_ch", FemuCtrl, zns_params.zns_num_ch, 2),
     DEFINE_PROP_UINT8("zns_num_lun", FemuCtrl, zns_params.zns_num_lun, 4),
+    DEFINE_PROP_UINT64("zns_latency", FemuCtrl, zns_params.zns_latency, 40000),
     DEFINE_PROP_END_OF_LIST(),
 };
 

--- a/hw/femu/femu.c
+++ b/hw/femu/femu.c
@@ -656,7 +656,8 @@ static Property femu_props[] = {
     DEFINE_PROP_UINT16("lmetasize", FemuCtrl, oc_params.sos, 16),
     DEFINE_PROP_UINT8("zns_num_ch", FemuCtrl, zns_params.zns_num_ch, 2),
     DEFINE_PROP_UINT8("zns_num_lun", FemuCtrl, zns_params.zns_num_lun, 4),
-    DEFINE_PROP_UINT64("zns_latency", FemuCtrl, zns_params.zns_latency, 40000),
+    DEFINE_PROP_UINT64("zns_read", FemuCtrl, zns_params.zns_read, 40000),
+    DEFINE_PROP_UINT64("zns_write", FemuCtrl, zns_params.zns_write, 200000),
     DEFINE_PROP_END_OF_LIST(),
 };
 

--- a/hw/femu/nvme.h
+++ b/hw/femu/nvme.h
@@ -1202,6 +1202,7 @@ typedef struct FemuCtrl {
     int32_t         nr_open_zones;
     int32_t         nr_active_zones;
 
+    struct zns_ch *ch;
     /* Coperd: OC2.0 FIXME */
     NvmeParams  params;
     FemuExtCtrlOps ext_ops;

--- a/hw/femu/nvme.h
+++ b/hw/femu/nvme.h
@@ -1148,6 +1148,7 @@ typedef struct NvmeParams {
 typedef struct ZNSCtrlParams {
     uint8_t  zns_num_ch;
     uint8_t  zns_num_lun;
+    uint64_t  zns_latency;
 } ZNSCtrlParams;
 
 typedef struct OcCtrlParams {

--- a/hw/femu/nvme.h
+++ b/hw/femu/nvme.h
@@ -1145,6 +1145,11 @@ typedef struct NvmeParams {
 #define FEMU_MAX_NUM_CHNLS (32)
 #define FEMU_MAX_NUM_CHIPS (128)
 
+typedef struct ZNSCtrlParams {
+    uint8_t  zns_num_ch;
+    uint8_t  zns_num_lun;
+} ZNSCtrlParams;
+
 typedef struct OcCtrlParams {
     uint16_t sec_size;
     uint8_t  secs_per_pg;
@@ -1202,7 +1207,9 @@ typedef struct FemuCtrl {
     int32_t         nr_open_zones;
     int32_t         nr_active_zones;
 
-    struct zns_ch *ch;
+    struct zns_ssd *zns;
+    ZNSCtrlParams zns_params;
+
     /* Coperd: OC2.0 FIXME */
     NvmeParams  params;
     FemuExtCtrlOps ext_ops;

--- a/hw/femu/nvme.h
+++ b/hw/femu/nvme.h
@@ -1148,7 +1148,8 @@ typedef struct NvmeParams {
 typedef struct ZNSCtrlParams {
     uint8_t  zns_num_ch;
     uint8_t  zns_num_lun;
-    uint64_t  zns_latency;
+    uint64_t  zns_read;
+    uint64_t zns_write;
 } ZNSCtrlParams;
 
 typedef struct OcCtrlParams {

--- a/hw/femu/zns/zns.c
+++ b/hw/femu/zns/zns.c
@@ -471,6 +471,127 @@ static void zns_finalize_zoned_write(NvmeNamespace *ns, NvmeRequest *req,
     }
 }
 
+// Add some function
+// --------------------------------
+static inline struct zns_ch *get_ch(struct zns_ssd *zns, struct ppa *ppa)
+{
+    return &(zns->ch[ppa->g.ch]);
+}
+
+static inline struct zns_fc *get_fc(struct zns_ssd *zns, struct ppa *ppa)
+{
+    struct zns_ch *ch = get_ch(zns, ppa);
+    return &(ch->fc[ppa->g.fc]);
+}
+
+static inline struct zns_blk *get_blk(struct zns_ssd *zns, struct ppa *ppa)
+{
+    struct zns_fc *fc = get_fc(zns, ppa);
+    return &(fc->blk[ppa->g.blk]);
+}
+
+static inline uint64_t zone_slba(FemuCtrl *n, uint32_t zone_idx)
+{
+    return (zone_idx) * n->zone_size;
+}
+
+static inline void check_addr(int a, int max)
+{
+   assert(a >= 0 && a < max);
+}
+
+static void advance_read_pointer(FemuCtrl *n)
+{
+    struct zns_ssd *zns = n->zns;
+    struct write_pointer *wpp = &zns->wp;
+    uint8_t num_ch = zns->num_ch;
+    uint8_t num_lun = zns->num_lun;
+
+    //printf("NUM CH: %"PRIu64"\n", wpp->ch);
+    check_addr(wpp->ch, num_ch);
+    wpp->ch++;
+    if (wpp->ch == num_ch) {
+        wpp->ch = 0;
+	check_addr(wpp->lun, num_lun);
+	wpp->lun++;
+	if(wpp->lun == num_lun) {
+	    wpp->lun = 0;
+
+	    assert(wpp->ch == 0);
+	    assert(wpp->lun == 0);
+	}
+    }
+}
+
+static inline struct ppa lpn_to_ppa(FemuCtrl *n, NvmeNamespace *ns, uint64_t lpn)
+{
+
+	uint32_t zone_idx = zns_zone_idx(ns, lpn);
+	//uint64_t off = lpn - zone_slba(n, zone_idx);
+	//uint64_t offset = off / 4096;
+
+	struct zns_ssd *zns = n->zns;
+	struct write_pointer *wpp = &zns->wp;
+	//uint64_t num_ch = zns->num_ch;
+	//uint64_t num_lun = zns->num_lun;
+	struct ppa ppa = {0};
+
+	//printf("OFFSET: %"PRIu64"\n", offset);
+	ppa.g.ch = wpp->ch;
+	ppa.g.fc = wpp->lun;
+	ppa.g.blk = zone_idx;
+
+    return ppa;
+}
+
+static uint64_t zns_advance_status(FemuCtrl *n, struct nand_cmd *ncmd,
+		struct ppa *ppa)
+{
+    int c = ncmd->cmd;
+
+    struct zns_ssd *zns = n->zns;
+    uint64_t nand_stime;
+    uint64_t req_stime = (ncmd->stime == 0) ? \
+        qemu_clock_get_ns(QEMU_CLOCK_REALTIME) : ncmd->stime;
+
+    struct zns_fc *fc = get_fc(zns, ppa);
+
+    uint64_t lat = 0;
+    uint64_t read_delay = n->zns_params.zns_read;
+    uint64_t write_delay = n->zns_params.zns_write;
+    uint64_t erase_delay = 2000000;
+   //200 us for write
+    switch (c) {
+    case NAND_READ:
+            nand_stime = (fc->next_fc_avail_time < req_stime) ? req_stime : \
+                    fc->next_fc_avail_time;
+
+	    fc->next_fc_avail_time = nand_stime + read_delay;
+            lat = fc->next_fc_avail_time - req_stime;
+
+	    break;
+    case NAND_WRITE:
+	    nand_stime = (fc->next_fc_avail_time < req_stime) ? req_stime : \
+		            fc->next_fc_avail_time;
+	    fc->next_fc_avail_time = nand_stime + write_delay;
+	    lat = fc->next_fc_avail_time - req_stime;
+
+	    break;
+    case NAND_ERASE:
+    	    nand_stime = (fc->next_fc_avail_time < req_stime) ? req_stime : \
+                            fc->next_fc_avail_time;
+            fc->next_fc_avail_time = nand_stime + erase_delay;
+            lat = fc->next_fc_avail_time - req_stime;
+
+            break;
+    default:
+	//lat = 0;
+	;
+    }
+    return lat;
+}
+//----------------------------------
+
 static uint64_t zns_advance_zone_wp(NvmeNamespace *ns, NvmeZone *zone,
                                     uint32_t nlb)
 {
@@ -502,6 +623,7 @@ struct zns_zone_reset_ctx {
 static void zns_aio_zone_reset_cb(NvmeRequest *req, NvmeZone *zone)
 {
     NvmeNamespace *ns = req->ns;
+    FemuCtrl *n = ns->ctrl;
 
     /* FIXME, We always assume reset SUCCESS */
     switch (zns_get_zone_state(zone)) {
@@ -519,6 +641,25 @@ static void zns_aio_zone_reset_cb(NvmeRequest *req, NvmeZone *zone)
         zns_assign_zone_state(ns, zone, NVME_ZONE_STATE_EMPTY);
     default:
         break;
+    }
+
+    struct zns_ssd *zns = n->zns;
+    uint64_t num_ch = zns->num_ch;
+    uint64_t num_lun = zns->num_lun;
+    struct ppa ppa;
+
+    for (int ch = 0; ch < num_ch; ch++){
+    	for (int lun = 0; lun < num_lun; lun++) {
+	    ppa.g.ch = ch;
+	    ppa.g.fc = lun;
+	    ppa.g.blk = zns_zone_idx(ns, zone->d.zslba);
+	    
+	    struct nand_cmd erase;
+	    erase.cmd = NAND_ERASE;
+	    erase.stime = 0;	    
+	    zns_advance_status(n, &erase, &ppa);
+	    
+	}
     }
 }
 
@@ -1046,119 +1187,6 @@ static uint16_t zns_map_dptr(FemuCtrl *n, size_t len, NvmeRequest *req)
     }
 }
 
-// Add some function
-// --------------------------------
-static inline struct zns_ch *get_ch(struct zns_ssd *zns, struct ppa *ppa)
-{
-    return &(zns->ch[ppa->g.ch]);
-}
-
-static inline struct zns_fc *get_fc(struct zns_ssd *zns, struct ppa *ppa)
-{
-    struct zns_ch *ch = get_ch(zns, ppa);
-    return &(ch->fc[ppa->g.fc]);
-}
-
-static inline struct zns_blk *get_blk(struct zns_ssd *zns, struct ppa *ppa)
-{
-    struct zns_fc *fc = get_fc(zns, ppa);
-    return &(fc->blk[ppa->g.blk]);
-}
-
-static inline uint64_t zone_slba(FemuCtrl *n, uint32_t zone_idx)
-{
-    return (zone_idx) * n->zone_size;
-}
-
-static inline void check_addr(int a, int max)
-{
-   assert(a >= 0 && a < max);
-}
-
-static void advance_read_pointer(FemuCtrl *n)
-{
-    struct zns_ssd *zns = n->zns;
-    struct write_pointer *wpp = &zns->wp;
-    uint8_t num_ch = zns->num_ch;
-    uint8_t num_lun = zns->num_lun;
-
-    //printf("NUM CH: %"PRIu64"\n", wpp->ch);
-    check_addr(wpp->ch, num_ch);
-    wpp->ch++;
-    if (wpp->ch == num_ch) {
-        wpp->ch = 0;
-	check_addr(wpp->lun, num_lun);
-	wpp->lun++;
-	if(wpp->lun == num_lun) {
-	    wpp->lun = 0;
-
-	    assert(wpp->ch == 0);
-	    assert(wpp->lun == 0);
-	}
-    }
-}
-
-static inline struct ppa lpn_to_ppa(FemuCtrl *n, NvmeNamespace *ns, uint64_t lpn)
-{
-
-	uint32_t zone_idx = zns_zone_idx(ns, lpn);
-	//uint64_t off = lpn - zone_slba(n, zone_idx);
-	//uint64_t offset = off / 4096;
-	
-	struct zns_ssd *zns = n->zns;
-	struct write_pointer *wpp = &zns->wp;
-	//uint64_t num_ch = zns->num_ch;
-	//uint64_t num_lun = zns->num_lun;
-	struct ppa ppa = {0};
-
-	//printf("OFFSET: %"PRIu64"\n", offset);
-	ppa.g.ch = wpp->ch;
-	ppa.g.fc = wpp->lun;
-	ppa.g.blk = zone_idx;
-
-    return ppa;
-}
-
-static uint64_t zns_advance_status(FemuCtrl *n, NvmeCmd *cmd, NvmeRequest *req,
-		struct ppa *ppa)
-{
-    NvmeRwCmd *rw = (NvmeRwCmd *)cmd;
-    uint8_t opcode = rw->opcode;
-
-    struct zns_ssd *zns = n->zns;
-    uint64_t nand_stime;
-    uint64_t req_stime = (req->stime == 0) ? \
-        qemu_clock_get_ns(QEMU_CLOCK_REALTIME) : req->stime;
-
-    struct zns_fc *fc = get_fc(zns, ppa);
-
-    uint64_t lat = 0;
-    uint64_t delay = n->zns_params.zns_latency;
-
-    switch (opcode) {
-    case NVME_CMD_READ:
-            nand_stime = (fc->next_fc_avail_time < req_stime) ? req_stime : \
-                    fc->next_fc_avail_time;
-
-	    fc->next_fc_avail_time = nand_stime + delay;
-            lat = fc->next_fc_avail_time - req_stime;
-
-	    break;
-    case NVME_CMD_WRITE:
-	    nand_stime = (fc->next_fc_avail_time < req_stime) ? req_stime : \
-		            fc->next_fc_avail_time;
-	    fc->next_fc_avail_time = nand_stime + delay;
-	    lat = fc->next_fc_avail_time - req_stime;
-
-	    break;
-    default:
-	//lat = 0;
-	;
-    }
-    return lat;
-}
-//----------------------------------
-
 static uint16_t zns_do_write(FemuCtrl *n, NvmeRequest *req, bool append,
                              bool wrz)
 {
@@ -1305,7 +1333,11 @@ static uint16_t zns_read(FemuCtrl *n, NvmeNamespace *ns, NvmeCmd *cmd,
         printf("\n\n");
 	*/
 
-	sublat = zns_advance_status(n, cmd, req, &ppa);
+	struct nand_cmd read;
+	read.cmd = NAND_READ;
+	read.stime = req->stime;
+
+	sublat = zns_advance_status(n, &read, &ppa);
         maxlat = (sublat > maxlat) ? sublat : maxlat;
     }
     //printf("MAX LATENCY: %"PRIu64"\n", maxlat);
@@ -1371,7 +1403,36 @@ static uint16_t zns_write(FemuCtrl *n, NvmeNamespace *ns, NvmeCmd *cmd,
     
     backend_rw(n->mbe, &req->qsg, &data_offset, req->is_write);
     zns_finalize_zoned_write(ns, req, false);
+    
+    uint64_t slpn = (slba)/4096;
+    uint64_t elpn = (slba + nlb - 1)/4096;
 
+    uint64_t lpn;
+    struct ppa ppa;
+    uint64_t sublat,maxlat=0;
+
+    for (lpn = slpn; lpn <= elpn; lpn++) {
+        ppa = lpn_to_ppa(n, ns, lpn);
+	advance_read_pointer(n);
+
+	/*
+	printf("LPN: %"PRIu64"\n", lpn);
+        printf("CHANNEL NUMBER: %d\n", ppa.g.ch);
+        printf("CHIP NUMBER: %d\n", ppa.g.fc);
+        printf("BLOCK NUMBER: %d\n", ppa.g.blk);
+        printf("\n\n");
+	*/
+
+	struct nand_cmd write;
+	write.cmd = NAND_WRITE;
+	write.stime = req->stime;
+
+	sublat = zns_advance_status(n, &write, &ppa);
+        maxlat = (sublat > maxlat) ? sublat : maxlat;
+    }
+    
+    req->reqlat = maxlat;
+    req->expire_time += maxlat;
     return NVME_SUCCESS;
 
 err:

--- a/hw/femu/zns/zns.h
+++ b/hw/femu/zns/zns.h
@@ -7,6 +7,12 @@
 
 #include "../nvme.h"
 
+enum {
+    NAND_READ =  0,
+    NAND_WRITE = 1,
+    NAND_ERASE = 2,
+};
+
 typedef struct QEMU_PACKED NvmeZonedResult {
     uint64_t slba;
 } NvmeZonedResult;
@@ -32,6 +38,11 @@ struct ppa {
 struct write_pointer {
     uint64_t ch;
     uint64_t lun;
+};
+
+struct nand_cmd {
+    int cmd;
+    uint64_t stime;
 };
 
 struct zns_blk {

--- a/hw/femu/zns/zns.h
+++ b/hw/femu/zns/zns.h
@@ -29,6 +29,11 @@ struct ppa {
     };
 };
 
+struct write_pointer {
+    uint64_t ch;
+    uint64_t lun;
+};
+
 struct zns_blk {
     uint64_t next_blk_avail_time;
 };
@@ -47,6 +52,7 @@ struct zns_ssd {
     uint64_t num_ch;
     uint64_t num_lun;
     struct zns_ch *ch;
+    struct write_pointer wp;
 };
 
 enum NvmeZoneAttr {

--- a/hw/femu/zns/zns.h
+++ b/hw/femu/zns/zns.h
@@ -2,8 +2,8 @@
 #define __FEMU_ZNS_H
 
 #define BLK_BITS    (32)
-#define FC_BITS     (4)
-#define CH_BITS     (2)
+#define FC_BITS     (8)
+#define CH_BITS     (8)
 
 #include "../nvme.h"
 
@@ -29,6 +29,11 @@ struct ppa {
     };
 };
 
+struct write_pointer {
+    uint64_t ch;
+    uint64_t lun;
+};
+
 struct zns_blk {
     uint64_t next_blk_avail_time;
 };
@@ -41,6 +46,13 @@ struct zns_fc {
 struct zns_ch {
     struct zns_fc *fc;
     uint64_t next_ch_avail_time;
+};
+
+struct zns_ssd {
+    uint64_t num_ch;
+    uint64_t num_lun;
+    struct zns_ch *ch;
+    struct write_pointer wp;
 };
 
 enum NvmeZoneAttr {
@@ -147,7 +159,7 @@ typedef struct NvmeNamespaceParams {
     uint32_t max_open_zones;
     uint32_t zd_extension_size;
 
-    struct zns_ch *ch;
+    struct zns_ssd *zns;
 } NvmeNamespaceParams;
 
 static inline uint32_t zns_nsid(NvmeNamespace *ns)

--- a/hw/femu/zns/zns.h
+++ b/hw/femu/zns/zns.h
@@ -29,11 +29,6 @@ struct ppa {
     };
 };
 
-struct write_pointer {
-    uint64_t ch;
-    uint64_t lun;
-};
-
 struct zns_blk {
     uint64_t next_blk_avail_time;
 };
@@ -52,7 +47,6 @@ struct zns_ssd {
     uint64_t num_ch;
     uint64_t num_lun;
     struct zns_ch *ch;
-    struct write_pointer wp;
 };
 
 enum NvmeZoneAttr {

--- a/hw/femu/zns/zns.h
+++ b/hw/femu/zns/zns.h
@@ -1,6 +1,10 @@
 #ifndef __FEMU_ZNS_H
 #define __FEMU_ZNS_H
 
+#define BLK_BITS    (32)
+#define FC_BITS     (4)
+#define CH_BITS     (2)
+
 #include "../nvme.h"
 
 typedef struct QEMU_PACKED NvmeZonedResult {
@@ -11,6 +15,33 @@ typedef struct NvmeIdCtrlZoned {
     uint8_t     zasl;
     uint8_t     rsvd1[4095];
 } NvmeIdCtrlZoned;
+
+struct ppa {
+    union {
+        struct {
+	    uint64_t blk : BLK_BITS;
+	    uint64_t fc  : FC_BITS;
+	    uint64_t ch  : CH_BITS;
+	    uint64_t rsv : 1;
+        } g;
+
+	uint64_t ppa;
+    };
+};
+
+struct zns_blk {
+    uint64_t next_blk_avail_time;
+};
+
+struct zns_fc {
+    struct zns_blk *blk;
+    uint64_t next_fc_avail_time;
+};
+
+struct zns_ch {
+    struct zns_fc *fc;
+    uint64_t next_ch_avail_time;
+};
 
 enum NvmeZoneAttr {
     NVME_ZA_FINISHED_BY_CTLR         = 1 << 0,
@@ -115,6 +146,8 @@ typedef struct NvmeNamespaceParams {
     uint32_t max_active_zones;
     uint32_t max_open_zones;
     uint32_t zd_extension_size;
+
+    struct zns_ch *ch;
 } NvmeNamespaceParams;
 
 static inline uint32_t zns_nsid(NvmeNamespace *ns)


### PR DESCRIPTION
- Add delay emulation for ZNS mode
- Add a logical zone mapping mechanism
- Update ``run-zns.sh`` script with some additional configuration knobs